### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+setup.bash
+node_modules/


### PR DESCRIPTION
Add setup.bash and node_modules/ in this file. This way, students won't need to each create their own and remove the credentials file from the git cache.